### PR TITLE
Single entity endpoints

### DIFF
--- a/rearguarde/api/resources.py
+++ b/rearguarde/api/resources.py
@@ -204,7 +204,7 @@ def register(api: Api):
     @api.response(200, 'Success')
     @api.response(400, 'Validation unsuccessful')
     @api.response(404, 'Resource not found')
-    class Tracktabs(Resource):
+    class TrackTabs(Resource):
         parser = api.parser()
         parser.add_argument('id', type=inputs.positive, help='Track tab ID', location='args')
         parser.add_argument('instrument', type=inputs.regex('^.{1,32}$'),
@@ -230,7 +230,7 @@ def register(api: Api):
     @api.response(200, 'Success')
     @api.response(400, 'Validation unsuccessful')
     @api.response(404, 'Resource not found')
-    class TracktabById(Resource):
+    class TrackTabById(Resource):
         def get(self, tracktab_id):
             """
             Get single track tab instance by its ID.

--- a/rearguarde/api/resources.py
+++ b/rearguarde/api/resources.py
@@ -32,7 +32,7 @@ def register(api: Api):
         @api.expect(parser, validate=True)
         def get(self):
             """
-            Artists GET method.
+            Get artists list and filter by specified parameters.
             """
             return ArtistRetriever(g.session).get_objects(remove_empty_parameters(
                 dict(urlparser.parse_qsl(request.query_string.decode()))))
@@ -51,7 +51,7 @@ def register(api: Api):
         @api.expect(parser, validate=True)
         def get(self):
             """
-            Genres GET method.
+            Get genres list and filter by specified parameters.
             """
             return GenreRetriever(g.session).get_objects(remove_empty_parameters(
                 self.parser.parse_args()))
@@ -79,7 +79,7 @@ def register(api: Api):
         @api.expect(parser, validate=True)
         def get(self):
             """
-            Releases GET method.
+            Get releases list and filter by specified parameters.
             """
             return ReleaseRetriever(g.session).get_objects(remove_empty_parameters(
                 dict(urlparser.parse_qsl(request.query_string.decode()))))
@@ -98,7 +98,7 @@ def register(api: Api):
         @api.expect(parser, validate=True)
         def get(self):
             """
-            Songs GET method.
+            Get songs list and filter by specified parameters.
             """
             return SongRetriever(g.session).get_objects(remove_empty_parameters(
                 dict(urlparser.parse_qsl(request.query_string.decode()))))
@@ -120,7 +120,7 @@ def register(api: Api):
         @api.expect(parser, validate=True)
         def get(self):
             """
-            Sheets GET method.
+            Get sheets list and filter by specified parameters.
             """
             return SheetRetriever(g.session).get_objects(remove_empty_parameters(
                 dict(urlparser.parse_qsl(request.query_string.decode()))))
@@ -145,7 +145,7 @@ def register(api: Api):
         @api.expect(parser, validate=True)
         def get(self):
             """
-            Track tabs GET method.
+            Get track tabs list and filter by specified parameters.
             """
             return TrackTabRetriever(g.session).get_objects(remove_empty_parameters(
                 dict(urlparser.parse_qsl(request.query_string.decode()))))

--- a/rearguarde/api/resources.py
+++ b/rearguarde/api/resources.py
@@ -71,6 +71,21 @@ def register(api: Api):
                 self.parser.parse_args()))
 
 
+    @ns.route('/genres/<genre_id>')
+    @api.param('genre_id', 'Genre ID')
+    @api.response(200, 'Success')
+    @api.response(400, 'Validation unsuccessful')
+    @api.response(404, 'Resource not found')
+    class GenreById(Resource):
+        def get(self, genre_id):
+            """
+            Get single genre instance by its ID.
+            """
+            abort_on_invalid_parameters(api, {'genre_id': genre_id})
+            retrieved = GenreRetriever(g.session).get_objects({'id': genre_id})
+            return retrieved[0] if retrieved else {}
+
+
     @ns.route('/releases')
     @api.response(200, 'Success')
     @api.response(400, 'Validation unsuccessful')
@@ -99,6 +114,21 @@ def register(api: Api):
                 self.parser.parse_args()))
 
 
+    @ns.route('/releases/<release_id>')
+    @api.param('release_id', 'Release ID')
+    @api.response(200, 'Success')
+    @api.response(400, 'Validation unsuccessful')
+    @api.response(404, 'Resource not found')
+    class ReleaseById(Resource):
+        def get(self, release_id):
+            """
+            Get single release instance by its ID.
+            """
+            abort_on_invalid_parameters(api, {'release_id': release_id})
+            retrieved = ReleaseRetriever(g.session).get_objects({'id': release_id})
+            return retrieved[0] if retrieved else {}
+
+
     @ns.route('/songs')
     @api.response(200, 'Success')
     @api.response(400, 'Validation unsuccessful')
@@ -116,6 +146,21 @@ def register(api: Api):
             """
             return SongRetriever(g.session).get_objects(remove_empty_parameters(
                 self.parser.parse_args()))
+
+
+    @ns.route('/songs/<song_id>')
+    @api.param('song_id', 'Song ID')
+    @api.response(200, 'Success')
+    @api.response(400, 'Validation unsuccessful')
+    @api.response(404, 'Resource not found')
+    class SongById(Resource):
+        def get(self, song_id):
+            """
+            Get single song instance by its ID.
+            """
+            abort_on_invalid_parameters(api, {'song_id': song_id})
+            retrieved = SongRetriever(g.session).get_objects({'id': song_id})
+            return retrieved[0] if retrieved else {}
 
 
     @ns.route('/sheets')
@@ -138,6 +183,21 @@ def register(api: Api):
             """
             return SheetRetriever(g.session).get_objects(remove_empty_parameters(
                 self.parser.parse_args()))
+
+
+    @ns.route('/sheets/<sheet_id>')
+    @api.param('sheet_id', 'Sheet ID')
+    @api.response(200, 'Success')
+    @api.response(400, 'Validation unsuccessful')
+    @api.response(404, 'Resource not found')
+    class SheetById(Resource):
+        def get(self, sheet_id):
+            """
+            Get single sheet instance by its ID.
+            """
+            abort_on_invalid_parameters(api, {'sheet_id': sheet_id})
+            retrieved = SheetRetriever(g.session).get_objects({'id': sheet_id})
+            return retrieved[0] if retrieved else {}
 
 
     @ns.route('/tracktabs')
@@ -163,3 +223,18 @@ def register(api: Api):
             """
             return TrackTabRetriever(g.session).get_objects(remove_empty_parameters(
                 self.parser.parse_args()))
+
+
+    @ns.route('/tracktabs/<tracktab_id>')
+    @api.param('tracktab_id', 'Track tab ID')
+    @api.response(200, 'Success')
+    @api.response(400, 'Validation unsuccessful')
+    @api.response(404, 'Resource not found')
+    class TracktabById(Resource):
+        def get(self, tracktab_id):
+            """
+            Get single track tab instance by its ID.
+            """
+            abort_on_invalid_parameters(api, {'tracktab_id': tracktab_id})
+            retrieved = TrackTabRetriever(g.session).get_objects({'id': tracktab_id})
+            return retrieved[0] if retrieved else {}

--- a/rearguarde/api/util.py
+++ b/rearguarde/api/util.py
@@ -1,2 +1,15 @@
+from flask_restx import Api
+
+INVALID_PARAMS_STATUS_CODE = 400
+
+
+def abort_on_invalid_parameters(api: Api, request_parameters: dict):
+    for key in request_parameters:
+        if key.endswith('_id') and int(request_parameters[key]) < 1:
+            api.abort(INVALID_PARAMS_STATUS_CODE, 'Input payload validation failed',
+                      **{key: f'Invalid {key}: {request_parameters[key]}. '
+                              + f'{key} must be a positive integer' for key in request_parameters})
+
+
 def remove_empty_parameters(parameter_values: dict):
     return {key: parameter_values[key] for key in parameter_values if parameter_values[key]}


### PR DESCRIPTION
This one brings API endpoints like `/resources/<entity>/<entity_id>`. I haven't used `api.parser` for parameter validation due to its inability to deal with path parameters. In lieu of that, I introduced wondrous `abort_on_invalid_parameters` function to throw HTTP 400 on incorrect resource params. Anyway, now I have a strong preference on query string parameters over URL path parameters.

![Screenshot from 2020-07-12 14-46-08](https://user-images.githubusercontent.com/21245917/87245631-88837b00-c44f-11ea-95b4-2a7d0ddc1e0b.png)
