### PR TITLE
Add songs-with-nested-artists endpoint

### DIFF
--- a/rearguarde/retrieval/retrievers.py
+++ b/rearguarde/retrieval/retrievers.py
@@ -75,6 +75,40 @@ class SongRetriever(AbstractRetriever):
         } for item in query.all()]
 
 
+class SongWithArtistsRetriever(AbstractRetriever):
+    underlying_class = Song
+    _substring_fields = ['name']
+
+    def _dictionarize_objects(self, query):
+        query = query.join(Song.release) \
+                     .join(Release.artists)
+
+        return [{
+            'id': item.id,
+            'name': item.name,
+            'trivia': item.trivia,
+            'cover_ids': [cover.id for cover in item.covers],
+            'original_id': item.original_id,
+            'release': {
+                'id': item.release.id,
+                'name': item.release.name,
+                'year': item.release.year,
+                'label': item.release.label,
+                'type': item.release.type,
+                'album_kind': item.release.album_kind,
+                'portrait_image_link': item.release.portrait_image_link,
+                'artists': [{
+                    'id': artist.id,
+                    'name': artist.name,
+                    'year_founded': artist.year_founded,
+                    'country': artist.country,
+                    'about': artist.about,
+                    'portrait_image_link': artist.portrait_image_link,
+                } for artist in item.release.artists]
+            },
+        } for item in query.all()]        
+
+
 class SheetRetriever(AbstractRetriever):
     underlying_class = Sheet
 


### PR DESCRIPTION
Covers [this](https://trello.com/c/FTFLSCqU/140-create-songs-with-artists-endpoint). The fragment of response after hitting the `/resources/songs-artists`:

```json
{
    "id": 19828,
    "cover_ids": [],
    "name": "La Grange",
    "original_id": null,
    "release": {
      "album_kind": "Studio",
      "artists": [
        {
          "about": "Their lyrics, often embellished with sexual innuendo, focus on their Texas roots and humor. Popular for their live performances, the group has staged several elaborate tours.",
          "country": "USA",
          "id": 28332,
          "name": "ZZ Top",
          "portrait_image_link": "https://drive.google.com/file/d/16tczXCIxSzdBW_M1hACsGq9zv_TujweY/view?usp=sharing",
          "year_founded": 1969
        },
        {
          "about": "The koolest band mom get the camera",
          "country": "Zimbabwe",
          "id": 20000,
          "name": "Kool",
          "portrait_image_link": null,
          "year_founded": 1969
        }
      ],
      "id": 2810133,
      "label": "London Records",
      "name": "Tres Hombres",
      "portrait_image_link": "https://drive.google.com/file/d/1h4MwV15oLJvVaXYAovT0K05CJQs3A6OF/view?usp=sharing",
      "type": "Album",
      "year": 1973
    },
    "trivia": null
  }
```