### PR TITLE
Introduce enums for release types and album kinds

### DIFF
--- a/rearguarde/migrations/versions/2021-06-12-e916b9b6fcaf-introduce_enum_for_.py
+++ b/rearguarde/migrations/versions/2021-06-12-e916b9b6fcaf-introduce_enum_for_.py
@@ -18,22 +18,22 @@ depends_on = None
 release_type = {
     'name': 'release_type',
     'values': [
-        'album',
-        'extended_play',
-        'long_play',
-        'single',
+        'ALBUM',
+        'EXTENDED_PLAY',
+        'LONG_PLAY',
+        'SINGLE',
     ],
 }
 
 album_kind = {
     'name': 'album_kind',
     'values': [
-        'compilation',
-        'cover',
-        'live',
-        'soundtrack',
-        'studio',
-        'tribute',
+        'COMPILATION',
+        'COVER',
+        'LIVE',
+        'SOUNDTRACK',
+        'STUDIO',
+        'TRIBUTE',
     ],
 }
 
@@ -49,13 +49,13 @@ def upgrade():
                    type_=sa.Enum(*release_type['values'], name=release_type['name']),
                    existing_type=sa.VARCHAR(length=32),
                    nullable=False,
-                   postgresql_using=f'lower(type)::{release_type["name"]}')
+                   postgresql_using=f'UPPER(type)::{release_type["name"]}')
 
         op.execute(f"CREATE TYPE {album_kind['name']} AS ENUM ({','.join(repr(x) for x in album_kind['values'])})")
         op.alter_column('release', 'album_kind',
                    type_=sa.Enum(*album_kind['values'], name=album_kind['name']),
                    existing_type=sa.VARCHAR(length=32),
-                   postgresql_using=f'lower(album_kind)::{album_kind["name"]}')
+                   postgresql_using=f'UPPER(album_kind)::{album_kind["name"]}')
 
 
 def downgrade():

--- a/rearguarde/migrations/versions/2021-06-12-e916b9b6fcaf-introduce_enum_for_.py
+++ b/rearguarde/migrations/versions/2021-06-12-e916b9b6fcaf-introduce_enum_for_.py
@@ -1,0 +1,77 @@
+"""Introduce enum for release types
+
+Revision ID: e916b9b6fcaf
+Revises: 26221590bf50
+Create Date: 2021-06-12 16:21:14.323481+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'e916b9b6fcaf'
+down_revision = '26221590bf50'
+branch_labels = None
+depends_on = None
+
+release_type = {
+    'name': 'release_type',
+    'values': [
+        'album',
+        'extended_play',
+        'long_play',
+        'single',
+    ],
+}
+
+album_kind = {
+    'name': 'album_kind',
+    'values': [
+        'compilation',
+        'cover',
+        'live',
+        'soundtrack',
+        'studio',
+        'tribute',
+    ],
+}
+
+
+def upgrade():
+    # Setting autocommit block to allow following migrations using new values,
+    # see https://makimo.pl/blog/2020/12/23/upgrading-postgresqls-enum-type-with-sqlalchemy-using-alembic-migration/
+    # and https://www.postgresql.org/docs/13/sql-altertype.html
+    with op.get_context().autocommit_block():
+
+        op.execute(f"CREATE TYPE {release_type['name']} AS ENUM ({','.join(repr(x) for x in release_type['values'])})")
+        op.alter_column('release', 'type',
+                   type_=sa.Enum(*release_type['values'], name=release_type['name']),
+                   existing_type=sa.VARCHAR(length=32),
+                   nullable=False,
+                   postgresql_using=f'lower(type)::{release_type["name"]}')
+
+        op.execute(f"CREATE TYPE {album_kind['name']} AS ENUM ({','.join(repr(x) for x in album_kind['values'])})")
+        op.alter_column('release', 'album_kind',
+                   type_=sa.Enum(*album_kind['values'], name=album_kind['name']),
+                   existing_type=sa.VARCHAR(length=32),
+                   postgresql_using=f'lower(album_kind)::{album_kind["name"]}')
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+
+        op.alter_column('release', 'album_kind',
+                   type_=sa.VARCHAR(length=32),
+                   existing_type=sa.Enum(*album_kind['values'], name=album_kind['name']),
+                   postgresql_using=f'album_kind::text')
+        op.execute('UPDATE release SET album_kind = INITCAP(album_kind)')
+        op.execute(f"DROP TYPE IF EXISTS {album_kind['name']}")
+
+        op.alter_column('release', 'type',
+                   type_=sa.VARCHAR(length=32),
+                   existing_type=sa.Enum(*release_type['values'], name=release_type['name']),
+                   nullable=True,
+                   postgresql_using=f'type::text')
+        op.execute('UPDATE release SET type = INITCAP(type)')
+        op.execute(f"DROP TYPE IF EXISTS {release_type['name']}")

--- a/rearguarde/model/crack.py
+++ b/rearguarde/model/crack.py
@@ -39,19 +39,19 @@ class GenreArtist(Base):
 
 
 class ReleaseType(NativeEnum):
-    ALBUM = 'album'
-    EXTENDED_PLAY = 'extended_play'
-    LONG_PLAY = 'long_play'
-    SINGLE = 'single'
+    ALBUM = 'ALBUM'
+    EXTENDED_PLAY = 'EXTENDED_PLAY'
+    LONG_PLAY = 'LONG_PLAY'
+    SINGLE = 'SINGLE'
 
 
 class AlbumKind(NativeEnum):
-    COMPILATION = 'compilation'
-    COVER = 'cover'
-    LIVE = 'live'
-    SOUNDTRACK = 'soundtrack'
-    STUDIO = 'studio'
-    TRIBUTE = 'tribute'
+    COMPILATION = 'COMPILATION'
+    COVER = 'COVER'
+    LIVE = 'LIVE'
+    SOUNDTRACK = 'SOUNDTRACK'
+    STUDIO = 'STUDIO'
+    TRIBUTE = 'TRIBUTE'
 
 
 class Release(Base):

--- a/rearguarde/model/crack.py
+++ b/rearguarde/model/crack.py
@@ -1,6 +1,7 @@
 from enum import Enum as NativeEnum
 
 from sqlalchemy import Column, Enum, Integer, String, Date, Text, Time, ForeignKey
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship, backref
 
 from model.base import Base
@@ -67,6 +68,14 @@ class Release(Base):
 
     genres = relationship(Genre, secondary='genre_release')
     artists = relationship(Artist, secondary='artist_release')
+
+    @hybrid_property
+    def type_formatted(self):
+        return self.type.value if self.type else None
+
+    @hybrid_property
+    def album_kind_formatted(self):
+        return self.album_kind.value if self.album_kind else None
 
 
 class GenreRelease(Base):

--- a/rearguarde/model/crack.py
+++ b/rearguarde/model/crack.py
@@ -1,4 +1,6 @@
-from sqlalchemy import Column, Integer, String, Date, Text, Time, ForeignKey
+from enum import Enum as NativeEnum
+
+from sqlalchemy import Column, Enum, Integer, String, Date, Text, Time, ForeignKey
 from sqlalchemy.orm import relationship, backref
 
 from model.base import Base
@@ -36,6 +38,22 @@ class GenreArtist(Base):
     artist_id = Column(Integer, ForeignKey(Artist.id), primary_key=True)
 
 
+class ReleaseType(NativeEnum):
+    ALBUM = 'album'
+    EXTENDED_PLAY = 'extended_play'
+    LONG_PLAY = 'long_play'
+    SINGLE = 'single'
+
+
+class AlbumKind(NativeEnum):
+    COMPILATION = 'compilation'
+    COVER = 'cover'
+    LIVE = 'live'
+    SOUNDTRACK = 'soundtrack'
+    STUDIO = 'studio'
+    TRIBUTE = 'tribute'
+
+
 class Release(Base):
     __tablename__ = 'release'
 
@@ -43,8 +61,8 @@ class Release(Base):
     name = Column(String(64))
     year = Column(Integer)
     label = Column(String(64))
-    type = Column(String(32))
-    album_kind = Column(String(32))
+    type = Column(Enum(ReleaseType, name='release_type'), nullable=False)
+    album_kind = Column(Enum(AlbumKind, name='album_kind'))
     portrait_image_link = Column(String(128))
 
     genres = relationship(Genre, secondary='genre_release')

--- a/rearguarde/retrieval/retrievers.py
+++ b/rearguarde/retrieval/retrievers.py
@@ -47,10 +47,10 @@ class ReleaseRetriever(AbstractRetriever):
                      .join(Release.songs, isouter=True)
         return [{
             'id': item.id,
-            'album_kind': item.album_kind,
+            'album_kind': item.album_kind_formatted,
             'label': item.label,
             'name': item.name,
-            'type': item.type,
+            'type': item.type_formatted,
             'portrait_image_link': item.portrait_image_link,
             'year': item.year,
             'artist_ids': [artist.id for artist in item.artists],
@@ -94,8 +94,8 @@ class SongWithArtistsRetriever(AbstractRetriever):
                 'name': item.release.name,
                 'year': item.release.year,
                 'label': item.release.label,
-                'type': item.release.type,
-                'album_kind': item.release.album_kind,
+                'type': item.release.type_formatted,
+                'album_kind': item.release.album_kind_formatted,
                 'portrait_image_link': item.release.portrait_image_link,
                 'artists': [{
                     'id': artist.id,


### PR DESCRIPTION
The research showed that `alembic` can _theoretically_ work with enums, but in my specific case no automatic column type detection occurred. Maybe it works with entirely new tables — when one one of the columns initially has predefined `enum` type.

Note there is also slightly challenging process of extending possible values set for already existing enumeration: https://stackoverflow.com/questions/14845203/altering-an-enum-field-using-alembic. But adjusting values shouldn't be that frequent so I believe this won't be a problem for us.